### PR TITLE
Update dependencies, add new supported framework identifiers, tune CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,75 @@
+language: csharp
+
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      env: CURRENTOS=UNDER_LINUX
+      mono: latest
+    - os: osx
+      osx_image: xcode7.1
+      env: CURRENTOS=UNDER_MACOSX
+      mono: none
+script:
+  # installing .NET Core SDK and Mono
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg; fi
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then sudo mv microsoft.gpg /etc/apt/trusted.gpg.d/microsoft.gpg; fi
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod trusty main" > /etc/apt/sources.list.d/dotnetdev.list'; fi
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then sudo apt-get install apt-transport-https; fi
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then sudo apt-get update; fi
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then sudo apt-get install dotnet-dev-1.1.8 dotnet-sdk-2.1.300-preview1-008174 mono-devel mono-complete; fi
+  - if [[ $CURRENTOS == "UNDER_MACOSX" ]]; then wget --retry-connrefused --waitretry=1 -O /tmp/dotnet-dev-osx-x64.1.1.8.pkg https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-osx-x64.1.1.8.pkg; fi
+  - if [[ $CURRENTOS == "UNDER_MACOSX" ]]; then wget --retry-connrefused --waitretry=1 -O /tmp/dotnet-sdk-2.1.300-preview1-008174-osx-x64.pkg https://download.microsoft.com/download/D/7/8/D788D3CD-44C4-487D-829B-413E914FB1C3/dotnet-sdk-2.1.300-preview1-008174-osx-x64.pkg; fi
+  - if [[ $CURRENTOS == "UNDER_MACOSX" ]]; then sudo installer -pkg /tmp/dotnet-dev-osx-x64.1.1.8.pkg -target /; fi
+  - if [[ $CURRENTOS == "UNDER_MACOSX" ]]; then sudo installer -pkg /tmp/dotnet-sdk-2.1.300-preview1-008174-osx-x64.pkg -target /; fi
+  - if [[ $CURRENTOS == "UNDER_MACOSX" ]]; then ln -s /usr/local/share/dotnet/dotnet /usr/local/bin/; fi
+
+  # install dotnet new nunit template
+  - dotnet new -i ./Content
+
+  # creating projects from templates
+  - dotnet new nunit -n CSharpNet1   --framework netcoreapp1.0 -lang c#; dotnet test CSharpNet1;
+  - dotnet new nunit -n FSharpNet1   --framework netcoreapp1.0 -lang f#; dotnet test FSharpNet1;
+  - dotnet new nunit -n VBasicNet1   --framework netcoreapp1.0 -lang vb; dotnet test VBasicNet1;
+
+  - dotnet new nunit -n CSharpNet11  --framework netcoreapp1.1 -lang c#; dotnet test CSharpNet11;
+  - dotnet new nunit -n FSharpNet11  --framework netcoreapp1.1 -lang f#; dotnet test FSharpNet11;
+  - dotnet new nunit -n VBasicNet11  --framework netcoreapp1.1 -lang vb; dotnet test VBasicNet11;
+
+  - dotnet new nunit -n CSharpNet2   --framework netcoreapp2.0 -lang c#; dotnet test CSharpNet2;
+  - dotnet new nunit -n FSharpNet2   --framework netcoreapp2.0 -lang f#; dotnet test FSharpNet2;
+  - dotnet new nunit -n VBasicNet2   --framework netcoreapp2.0 -lang vb; dotnet test VBasicNet2;
+
+  - dotnet new nunit -n CSharpNet21  --framework netcoreapp2.1 -lang c#; dotnet test CSharpNet21;
+  - dotnet new nunit -n FSharpNet21  --framework netcoreapp2.1 -lang f#; dotnet test FSharpNet21;
+  - dotnet new nunit -n VBasicNet21  --framework netcoreapp2.1 -lang vb; dotnet test VBasicNet21;
+
+  # specify FrameworkPathOverride to run tests under Mono
+  - export FrameworkPathOverride=/usr/lib/mono/4.7-api
+
+  # run tests
+  # unfortunately, F# under full .NET Framework issues a compilation error, the issue is in F# compiler, disable tests for now
+  # unfortunately, Mono under Mac OSX could not resolve .NET Framework assemblies and issues many errors, disable tests for now
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then dotnet new nunit -n CSharpNet45  --framework net45 -lang c#; dotnet test CSharpNet45; fi
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then dotnet new nunit -n VBasicNet45  --framework net45 -lang vb; dotnet test VBasicNet45; fi
+
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then dotnet new nunit -n CSharpNet451 --framework net451 -lang c#; dotnet test CSharpNet451; fi
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then dotnet new nunit -n VBasicNet451 --framework net451 -lang vb; dotnet test VBasicNet451; fi
+
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then dotnet new nunit -n CSharpNet452 --framework net452 -lang c#; dotnet test CSharpNet452; fi
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then dotnet new nunit -n VBasicNet452 --framework net452 -lang vb; dotnet test VBasicNet452; fi
+
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then dotnet new nunit -n CSharpNet46  --framework net46 -lang c#; dotnet test CSharpNet46; fi
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then dotnet new nunit -n VBasicNet46  --framework net46 -lang vb; dotnet test VBasicNet46; fi
+
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then dotnet new nunit -n CSharpNet461 --framework net461 -lang c#; dotnet test CSharpNet461; fi
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then dotnet new nunit -n VBasicNet461 --framework net461 -lang vb; dotnet test VBasicNet461; fi
+
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then dotnet new nunit -n CSharpNet462 --framework net462 -lang c#; dotnet test CSharpNet462; fi
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then dotnet new nunit -n VBasicNet462 --framework net462 -lang vb; dotnet test VBasicNet462; fi
+
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then dotnet new nunit -n CSharpNet47 --framework net47 -lang c#; dotnet test CSharpNet47; fi
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then dotnet new nunit -n VBasicNet47 --framework net47 -lang vb; dotnet test VBasicNet47; fi
+
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then dotnet new nunit -n CSharpNet471 --framework net471 -lang c#; dotnet test CSharpNet471; fi
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then dotnet new nunit -n VBasicNet471 --framework net471 -lang vb; dotnet test VBasicNet471; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,21 +28,21 @@ script:
   - dotnet new -i ./Content
 
   # creating projects from templates
-  - dotnet new nunit -n CSharpNet1   --framework netcoreapp1.0 -lang c#; dotnet test CSharpNet1;
-  - dotnet new nunit -n FSharpNet1   --framework netcoreapp1.0 -lang f#; dotnet test FSharpNet1;
-  - dotnet new nunit -n VBasicNet1   --framework netcoreapp1.0 -lang vb; dotnet test VBasicNet1;
+  - dotnet new nunit -n CSharpNetCore1   --framework netcoreapp1.0 -lang c#; dotnet test CSharpNetCore1;
+  - dotnet new nunit -n FSharpNetCore1   --framework netcoreapp1.0 -lang f#; dotnet test FSharpNetCore1;
+  - dotnet new nunit -n VBasicNetCore1   --framework netcoreapp1.0 -lang vb; dotnet test VBasicNetCore1;
 
-  - dotnet new nunit -n CSharpNet11  --framework netcoreapp1.1 -lang c#; dotnet test CSharpNet11;
-  - dotnet new nunit -n FSharpNet11  --framework netcoreapp1.1 -lang f#; dotnet test FSharpNet11;
-  - dotnet new nunit -n VBasicNet11  --framework netcoreapp1.1 -lang vb; dotnet test VBasicNet11;
+  - dotnet new nunit -n CSharpNetCore11  --framework netcoreapp1.1 -lang c#; dotnet test CSharpNetCore11;
+  - dotnet new nunit -n FSharpNetCore11  --framework netcoreapp1.1 -lang f#; dotnet test FSharpNetCore11;
+  - dotnet new nunit -n VBasicNetCore11  --framework netcoreapp1.1 -lang vb; dotnet test VBasicNetCore11;
 
-  - dotnet new nunit -n CSharpNet2   --framework netcoreapp2.0 -lang c#; dotnet test CSharpNet2;
-  - dotnet new nunit -n FSharpNet2   --framework netcoreapp2.0 -lang f#; dotnet test FSharpNet2;
-  - dotnet new nunit -n VBasicNet2   --framework netcoreapp2.0 -lang vb; dotnet test VBasicNet2;
+  - dotnet new nunit -n CSharpNetCore2   --framework netcoreapp2.0 -lang c#; dotnet test CSharpNetCore2;
+  - dotnet new nunit -n FSharpNetCore2   --framework netcoreapp2.0 -lang f#; dotnet test FSharpNetCore2;
+  - dotnet new nunit -n VBasicNetCore2   --framework netcoreapp2.0 -lang vb; dotnet test VBasicNetCore2;
 
-  - dotnet new nunit -n CSharpNet21  --framework netcoreapp2.1 -lang c#; dotnet test CSharpNet21;
-  - dotnet new nunit -n FSharpNet21  --framework netcoreapp2.1 -lang f#; dotnet test FSharpNet21;
-  - dotnet new nunit -n VBasicNet21  --framework netcoreapp2.1 -lang vb; dotnet test VBasicNet21;
+  - dotnet new nunit -n CSharpNetCore21  --framework netcoreapp2.1 -lang c#; dotnet test CSharpNetCore21;
+  - dotnet new nunit -n FSharpNetCore21  --framework netcoreapp2.1 -lang f#; dotnet test FSharpNetCore21;
+  - dotnet new nunit -n VBasicNetCore21  --framework netcoreapp2.1 -lang vb; dotnet test VBasicNetCore21;
 
   # specify FrameworkPathOverride to run tests under Mono
   - export FrameworkPathOverride=/usr/lib/mono/4.7-api
@@ -50,6 +50,12 @@ script:
   # run tests
   # unfortunately, F# under full .NET Framework issues a compilation error, the issue is in F# compiler, disable tests for now
   # unfortunately, Mono under Mac OSX could not resolve .NET Framework assemblies and issues many errors, disable tests for now
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then dotnet new nunit -n CSharpNet35  --framework net35 -lang c#; dotnet test CSharpNet35; fi
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then dotnet new nunit -n VBasicNet35  --framework net35 -lang vb; dotnet test VBasicNet35; fi
+
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then dotnet new nunit -n CSharpNet40  --framework net40 -lang c#; dotnet test CSharpNet40; fi
+  - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then dotnet new nunit -n VBasicNet40  --framework net40 -lang vb; dotnet test VBasicNet40; fi
+
   - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then dotnet new nunit -n CSharpNet45  --framework net45 -lang c#; dotnet test CSharpNet45; fi
   - if [[ $CURRENTOS == "UNDER_LINUX" ]]; then dotnet new nunit -n VBasicNet45  --framework net45 -lang vb; dotnet test VBasicNet45; fi
 

--- a/Content/dotnet-new-nunit-csharp/.template.config/template.json
+++ b/Content/dotnet-new-nunit-csharp/.template.config/template.json
@@ -44,6 +44,14 @@
           "description": "Target netcoreapp2.1"
         },
         {
+          "choice": "net35",
+          "description": "Target net35"
+        },
+        {
+          "choice": "net40",
+          "description": "Target net40"
+        },
+        {
           "choice": "net45",
           "description": "Target net45"
         },

--- a/Content/dotnet-new-nunit-csharp/.template.config/template.json
+++ b/Content/dotnet-new-nunit-csharp/.template.config/template.json
@@ -38,6 +38,42 @@
         {
           "choice": "netcoreapp2.0",
           "description": "Target netcoreapp2.0"
+        },
+        {
+          "choice": "netcoreapp2.1",
+          "description": "Target netcoreapp2.1"
+        },
+        {
+          "choice": "net45",
+          "description": "Target net45"
+        },
+        {
+          "choice": "net451",
+          "description": "Target net451"
+        },
+        {
+          "choice": "net452",
+          "description": "Target net452"
+        },
+        {
+          "choice": "net46",
+          "description": "Target net46"
+        },
+        {
+          "choice": "net461",
+          "description": "Target net461"
+        },
+        {
+          "choice": "net462",
+          "description": "Target net462"
+        },
+        {
+          "choice": "net47",
+          "description": "Target net47"
+        },
+        {
+          "choice": "net471",
+          "description": "Target net471"
         }
       ],
       "replaces": "netcoreapp2.0",

--- a/Content/dotnet-new-nunit-csharp/Company.TestProject1.csproj
+++ b/Content/dotnet-new-nunit-csharp/Company.TestProject1.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.10.0" />
+    <PackageReference Include="nunit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
   </ItemGroup>

--- a/Content/dotnet-new-nunit-csharp/Company.TestProject1.csproj
+++ b/Content/dotnet-new-nunit-csharp/Company.TestProject1.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="nunit" Version="3.10.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
   </ItemGroup>
 
 </Project>

--- a/Content/dotnet-new-nunit-fsharp/.template.config/template.json
+++ b/Content/dotnet-new-nunit-fsharp/.template.config/template.json
@@ -44,6 +44,14 @@
           "description": "Target netcoreapp2.1"
         },
         {
+          "choice": "net35",
+          "description": "Target net35"
+        },
+        {
+          "choice": "net40",
+          "description": "Target net40"
+        },
+        {
           "choice": "net45",
           "description": "Target net45"
         },

--- a/Content/dotnet-new-nunit-fsharp/.template.config/template.json
+++ b/Content/dotnet-new-nunit-fsharp/.template.config/template.json
@@ -38,6 +38,42 @@
         {
           "choice": "netcoreapp2.0",
           "description": "Target netcoreapp2.0"
+        },
+        {
+          "choice": "netcoreapp2.1",
+          "description": "Target netcoreapp2.1"
+        },
+        {
+          "choice": "net45",
+          "description": "Target net45"
+        },
+        {
+          "choice": "net451",
+          "description": "Target net451"
+        },
+        {
+          "choice": "net452",
+          "description": "Target net452"
+        },
+        {
+          "choice": "net46",
+          "description": "Target net46"
+        },
+        {
+          "choice": "net461",
+          "description": "Target net461"
+        },
+        {
+          "choice": "net462",
+          "description": "Target net462"
+        },
+        {
+          "choice": "net47",
+          "description": "Target net47"
+        },
+        {
+          "choice": "net471",
+          "description": "Target net471"
         }
       ],
       "replaces": "netcoreapp2.0",

--- a/Content/dotnet-new-nunit-fsharp/Company.TestProject1.fsproj
+++ b/Content/dotnet-new-nunit-fsharp/Company.TestProject1.fsproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.10.0" />
+    <PackageReference Include="nunit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
   </ItemGroup>

--- a/Content/dotnet-new-nunit-fsharp/Company.TestProject1.fsproj
+++ b/Content/dotnet-new-nunit-fsharp/Company.TestProject1.fsproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="nunit" Version="3.10.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Content/dotnet-new-nunit-visualbasic/.template.config/template.json
+++ b/Content/dotnet-new-nunit-visualbasic/.template.config/template.json
@@ -44,6 +44,14 @@
           "description": "Target netcoreapp2.1"
         },
         {
+          "choice": "net35",
+          "description": "Target net35"
+        },
+        {
+          "choice": "net40",
+          "description": "Target net40"
+        },
+        {
           "choice": "net45",
           "description": "Target net45"
         },

--- a/Content/dotnet-new-nunit-visualbasic/.template.config/template.json
+++ b/Content/dotnet-new-nunit-visualbasic/.template.config/template.json
@@ -38,6 +38,42 @@
         {
           "choice": "netcoreapp2.0",
           "description": "Target netcoreapp2.0"
+        },
+        {
+          "choice": "netcoreapp2.1",
+          "description": "Target netcoreapp2.1"
+        },
+        {
+          "choice": "net45",
+          "description": "Target net45"
+        },
+        {
+          "choice": "net451",
+          "description": "Target net451"
+        },
+        {
+          "choice": "net452",
+          "description": "Target net452"
+        },
+        {
+          "choice": "net46",
+          "description": "Target net46"
+        },
+        {
+          "choice": "net461",
+          "description": "Target net461"
+        },
+        {
+          "choice": "net462",
+          "description": "Target net462"
+        },
+        {
+          "choice": "net47",
+          "description": "Target net47"
+        },
+        {
+          "choice": "net471",
+          "description": "Target net471"
         }
       ],
       "replaces": "netcoreapp2.0",

--- a/Content/dotnet-new-nunit-visualbasic/Company.TestProject1.vbproj
+++ b/Content/dotnet-new-nunit-visualbasic/Company.TestProject1.vbproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.10.0" />
+    <PackageReference Include="nunit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
   </ItemGroup>

--- a/Content/dotnet-new-nunit-visualbasic/Company.TestProject1.vbproj
+++ b/Content/dotnet-new-nunit-visualbasic/Company.TestProject1.vbproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="nunit" Version="3.10.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
   </ItemGroup>
 
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,12 @@ build_script:
   - dotnet new nunit -n VBasicNetCore21  --framework netcoreapp2.1 -lang vb
 
   # unfortunately, F# under full .NET Framework issues a compilation error, the issue is in F# compiler
+  - dotnet new nunit -n CSharpNet35  --framework net35 -lang c#
+  - dotnet new nunit -n VBasicNet35  --framework net35 -lang vb
+
+  - dotnet new nunit -n CSharpNet40  --framework net40 -lang c#
+  - dotnet new nunit -n VBasicNet40  --framework net40 -lang vb
+
   - dotnet new nunit -n CSharpNet45  --framework net45 -lang c#
   - dotnet new nunit -n VBasicNet45  --framework net45 -lang vb
 
@@ -65,6 +71,14 @@ test_script:
   - dotnet test CSharpNetCore21
   - dotnet test FSharpNetCore21
   - dotnet test VBasicNetCore21
+
+  - msbuild /p:FrameworkPathOverride="%programfiles(x86)%\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client" CSharpNet35
+  - msbuild /p:FrameworkPathOverride="%programfiles(x86)%\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client" VBasicNet35
+  - dotnet test CSharpNet35 --no-build
+  - dotnet test VBasicNet35 --no-build
+
+  - dotnet test CSharpNet40
+  - dotnet test VBasicNet40
 
   - dotnet test CSharpNet45
   - dotnet test VBasicNet45

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,94 @@
+image: Visual Studio 2017 Preview
+version: 1.0.{build}
+platform:
+  - Any CPU
+configuration:
+  - Release
+build_script:
+  # todo: nuget pack and install templates from nuget package
+  - nuget pack nunit-template.nuspec
+  - dotnet new -i ./Content
+
+  - dotnet new nunit -n CSharpNetCore1   --framework netcoreapp1.0 -lang c#
+  - dotnet new nunit -n FSharpNetCore1   --framework netcoreapp1.0 -lang f#
+  - dotnet new nunit -n VBasicNetCore1   --framework netcoreapp1.0 -lang vb
+
+  - dotnet new nunit -n CSharpNetCore11  --framework netcoreapp1.1 -lang c#
+  - dotnet new nunit -n FSharpNetCore11  --framework netcoreapp1.1 -lang f#
+  - dotnet new nunit -n VBasicNetCore11  --framework netcoreapp1.1 -lang vb
+
+  - dotnet new nunit -n CSharpNetCore2   --framework netcoreapp2.0 -lang c#
+  - dotnet new nunit -n FSharpNetCore2   --framework netcoreapp2.0 -lang f#
+  - dotnet new nunit -n VBasicNetCore2   --framework netcoreapp2.0 -lang vb
+
+  - dotnet new nunit -n CSharpNetCore21  --framework netcoreapp2.1 -lang c#
+  - dotnet new nunit -n FSharpNetCore21  --framework netcoreapp2.1 -lang f#
+  - dotnet new nunit -n VBasicNetCore21  --framework netcoreapp2.1 -lang vb
+
+  # unfortunately, F# under full .NET Framework issues a compilation error, the issue is in F# compiler
+  - dotnet new nunit -n CSharpNet45  --framework net45 -lang c#
+  - dotnet new nunit -n VBasicNet45  --framework net45 -lang vb
+
+  - dotnet new nunit -n CSharpNet451 --framework net451 -lang c#
+  - dotnet new nunit -n VBasicNet451 --framework net451 -lang vb
+
+  - dotnet new nunit -n CSharpNet452 --framework net452 -lang c#
+  - dotnet new nunit -n VBasicNet452 --framework net452 -lang vb
+
+  - dotnet new nunit -n CSharpNet46  --framework net46 -lang c#
+  - dotnet new nunit -n VBasicNet46  --framework net46 -lang vb
+
+  - dotnet new nunit -n CSharpNet461 --framework net461 -lang c#
+  - dotnet new nunit -n VBasicNet461 --framework net461 -lang vb
+
+  - dotnet new nunit -n CSharpNet462 --framework net462 -lang c#
+  - dotnet new nunit -n VBasicNet462 --framework net462 -lang vb
+
+  - dotnet new nunit -n CSharpNet47 --framework net47 -lang c#
+  - dotnet new nunit -n VBasicNet47 --framework net47 -lang vb
+
+  - dotnet new nunit -n CSharpNet471 --framework net471 -lang c#
+  - dotnet new nunit -n VBasicNet471 --framework net471 -lang vb
+test_script:
+  - dotnet test CSharpNetCore1
+  - dotnet test FSharpNetCore1
+  - dotnet test VBasicNetCore1
+
+  - dotnet test CSharpNetCore11
+  - dotnet test FSharpNetCore11
+  - dotnet test VBasicNetCore11
+
+  - dotnet test CSharpNetCore2
+  - dotnet test FSharpNetCore2
+  - dotnet test VBasicNetCore2
+
+  - dotnet test CSharpNetCore21
+  - dotnet test FSharpNetCore21
+  - dotnet test VBasicNetCore21
+
+  - dotnet test CSharpNet45
+  - dotnet test VBasicNet45
+
+  - dotnet test CSharpNet451
+  - dotnet test VBasicNet451
+
+  - dotnet test CSharpNet452
+  - dotnet test VBasicNet452
+
+  - dotnet test CSharpNet46
+  - dotnet test VBasicNet46
+
+  - dotnet test CSharpNet461
+  - dotnet test VBasicNet461
+
+  - dotnet test CSharpNet462
+  - dotnet test VBasicNet462
+
+  - dotnet test CSharpNet47
+  - dotnet test VBasicNet47
+
+  - dotnet test CSharpNet471
+  - dotnet test VBasicNet471
+
+artifacts:
+  - path: '*.nupkg'

--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,11 @@
 19 March 2018, v1.4.0
 ---------------------
 
-- update nunit dependency to v3.10.0
+- update nunit dependency to v3.10.1
 - update NUnit3TestAdapter dependency to v3.10.0
 - update Microsoft.NET.Test.Sdk dependency to v15.6.1
 - add new `--framework` supported parameters:
-    + .NET Framework versions (net40, net45, net451, net452, net46, net461, net462, net47, net471)
+    + .NET Framework versions (net35, net40, net45, net451, net452, net46, net461, net462, net47, net471)
     + .NET Core 2.1 (netcoreapp2.1)
 - add CI using travis-ci (linux, mac osx) and appveyor-ci (windows)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,14 @@
+19 March 2018, v1.4.0
+---------------------
+
+- update nunit dependency to v3.10.0
+- update NUnit3TestAdapter dependency to v3.10.0
+- update Microsoft.NET.Test.Sdk dependency to v15.6.1
+- add new `--framework` supported parameters:
+    + .NET Framework versions (net40, net45, net451, net452, net46, net461, net462, net47, net471)
+    + .NET Core 2.1 (netcoreapp2.1)
+- add CI using travis-ci (linux, mac osx) and appveyor-ci (windows)
+
 14 November 2017, v1.3.0
 ------------------------
 

--- a/nunit-template.nuspec
+++ b/nunit-template.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>NUnit3.DotNetNew.Template</id>
     <title>NUnit 3 template for dotnet-new</title>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
     <description>Project and item templates containing basic NUnit 3 Test Project.</description>
     <tags>NUnit dotnet core</tags>
     <authors>akharlov</authors>
@@ -16,9 +16,12 @@
       <packageType name="Template" />
     </packageTypes>
     <releaseNotes>
-- use nunit v3.9.0
-- use NUnit3TestAdapter v3.9.0
-- use Microsoft.NET.Test.Sdk v15.5.0
+- update nunit dependency to v3.10.0
+- update NUnit3TestAdapter dependency to v3.10.0
+- update Microsoft.NET.Test.Sdk dependency to v15.6.0
+- add new `--framework` supported parameters:
+    + .NET Framework versions (net40, net45, net451, net452, net46, net461, net462, net47, net471)
+    + .NET Core 2.1 (netcoreapp2.1)
     </releaseNotes>
   </metadata>
   <files>

--- a/nunit-template.nuspec
+++ b/nunit-template.nuspec
@@ -16,11 +16,11 @@
       <packageType name="Template" />
     </packageTypes>
     <releaseNotes>
-- update nunit dependency to v3.10.0
+- update nunit dependency to v3.10.1
 - update NUnit3TestAdapter dependency to v3.10.0
-- update Microsoft.NET.Test.Sdk dependency to v15.6.0
+- update Microsoft.NET.Test.Sdk dependency to v15.6.1
 - add new `--framework` supported parameters:
-    + .NET Framework versions (net40, net45, net451, net452, net46, net461, net462, net47, net471)
+    + .NET Framework versions (net35, net40, net45, net451, net452, net46, net461, net462, net47, net471)
     + .NET Core 2.1 (netcoreapp2.1)
     </releaseNotes>
   </metadata>

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,11 @@
 NUnit 3 Test Project Template for `dotnet new` CLI
 ==================================================
 
-|              | Status
-|--------------|:--------------:
-| nuget        | [![NUnit 3 Test Project Template for dotnet-new CLI](https://buildstats.info/nuget/NUnit3.DotNetNew.Template)](https://www.nuget.org/packages/NUnit3.DotNetNew.Template/)
+|                 | Status
+|-----------------|:--------------:
+| nuget           | [![NUnit 3 Test Project Template for dotnet-new CLI](https://buildstats.info/nuget/NUnit3.DotNetNew.Template)](https://www.nuget.org/packages/NUnit3.DotNetNew.Template/)
+| Windows         | [![Build status](https://ci.appveyor.com/api/projects/status/pb11n8ynftdnmlu4/branch/master?svg=true)](https://ci.appveyor.com/project/halex2005/dotnet-new-nunit-g8axg/branch/master)
+| Linux & Mac OSX | [![Build Status](https://travis-ci.org/nunit/dotnet-new-nunit.svg?branch=master)](https://travis-ci.org/nunit/dotnet-new-nunit)
 
 This repository contains a set of project templates to be used when creating projects from .NET Core `dotnet new` command line interface (C#, F# and Visual Basic project templates are supported).
 


### PR DESCRIPTION
- update nunit dependency to v3.10.1
- update NUnit3TestAdapter dependency to v3.10.0
- update Microsoft.NET.Test.Sdk dependency to v15.6.1
- add new `--framework` supported parameters:
    + .NET Framework versions (net35, net40, net45, net451, net452, net46, net461, net462, net47, net471)
    + .NET Core 2.1 (netcoreapp2.1)
- add CI using travis-ci (linux, mac osx) and appveyor-ci (windows)