### PR TITLE
open test files if project is created by visual studio

### DIFF
--- a/Content/dotnet-new-nunit-csharp/.template.config/template.json
+++ b/Content/dotnet-new-nunit-csharp/.template.config/template.json
@@ -126,6 +126,16 @@
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
       "continueOnError": true
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens UnitTest1.cs in the editor",
+      "manualInstructions": [ ],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "args": {
+        "files": "1"
+      },
+      "continueOnError": true
     }
   ]
 }

--- a/Content/dotnet-new-nunit-fsharp/.template.config/template.json
+++ b/Content/dotnet-new-nunit-fsharp/.template.config/template.json
@@ -126,6 +126,16 @@
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
       "continueOnError": true
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens UnitTest1.fs in the editor",
+      "manualInstructions": [ ],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "args": {
+        "files": "1"
+      },
+      "continueOnError": true
     }
   ]
 }

--- a/Content/dotnet-new-nunit-visualbasic/.template.config/template.json
+++ b/Content/dotnet-new-nunit-visualbasic/.template.config/template.json
@@ -126,6 +126,16 @@
       ],
       "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
       "continueOnError": true
+    },
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+      "description": "Opens UnitTest1.vb in the editor",
+      "manualInstructions": [ ],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "args": {
+        "files": "1"
+      },
+      "continueOnError": true
     }
   ]
 }


### PR DESCRIPTION
With this new post action step, if the project is created by Visual Studio (not `dotnetcli` or `dotnetcli-preview`) we open the test file in the editor.