### PR TITLE
Remove [<TestClass>] attribute from F# classes

### DIFF
--- a/Content/dotnet-new-nunit-fsharp-test-item/UnitTest1.fs
+++ b/Content/dotnet-new-nunit-fsharp-test-item/UnitTest1.fs
@@ -2,7 +2,6 @@ namespace Tests
 
 open NUnit.Framework
 
-[<TestClass>]
 type UnitTest1 () =
 
     [<SetUp>]

--- a/Content/dotnet-new-nunit-fsharp/UnitTest1.fs
+++ b/Content/dotnet-new-nunit-fsharp/UnitTest1.fs
@@ -2,7 +2,6 @@ namespace Tests
 
 open NUnit.Framework
 
-[<TestClass>]
 type TestClass () =
 
     [<SetUp>]


### PR DESCRIPTION
These don't appear to be necessary, and at least in the project template case, result in a warning.