### PR TITLE
Fix default namespace based on project name

### DIFF
--- a/Content/dotnet-new-nunit-csharp/Company.TestProject1.csproj
+++ b/Content/dotnet-new-nunit-csharp/Company.TestProject1.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp2.1</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
 
     <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
     <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>

--- a/Content/dotnet-new-nunit-csharp/UnitTest1.cs
+++ b/Content/dotnet-new-nunit-csharp/UnitTest1.cs
@@ -1,6 +1,6 @@
 using NUnit.Framework;
 
-namespace Tests
+namespace Company.TestProject1
 {
     public class Tests
     {

--- a/Content/dotnet-new-nunit-fsharp/Company.TestProject1.fsproj
+++ b/Content/dotnet-new-nunit-fsharp/Company.TestProject1.fsproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp2.1</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
+    <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
 
     <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
     <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>

--- a/Content/dotnet-new-nunit-fsharp/UnitTest1.fs
+++ b/Content/dotnet-new-nunit-fsharp/UnitTest1.fs
@@ -1,4 +1,4 @@
-namespace Tests
+namespace Company.TestProject1
 
 open NUnit.Framework
 

--- a/Content/dotnet-new-nunit-visualbasic/UnitTest1.vb
+++ b/Content/dotnet-new-nunit-visualbasic/UnitTest1.vb
@@ -1,6 +1,6 @@
 Imports NUnit.Framework
 
-Namespace Tests
+Namespace Company.TestProject1
 
     Public Class Tests
 


### PR DESCRIPTION
This PR fixes the namespace pf generated project when use
```cmd
dotnet new nunit -n MyCompany.Super.TestProject
```

Current tool generates
```csharp
namespace Tests
{
    public class Tests
    {
       
    }
}
```

Instead of it we need:
```csharp
namespace MyCompany.Super.TestProject
{
    public class Tests
    {
       
    }
}
```

Templates for F# and VB are also fixed.