### PR TITLE
#27: Change to module, update deps, add GenerateProgramFile

### DIFF
--- a/Content/dotnet-new-nunit-csharp/Company.TestProject1.csproj
+++ b/Content/dotnet-new-nunit-csharp/Company.TestProject1.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.11.0" />
+    <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
   </ItemGroup>
 
 </Project>

--- a/Content/dotnet-new-nunit-fsharp-test-item/UnitTest1.fs
+++ b/Content/dotnet-new-nunit-fsharp-test-item/UnitTest1.fs
@@ -1,13 +1,11 @@
-namespace Tests
+module Tests
 
 open NUnit.Framework
 
-type UnitTest1 () =
+[<SetUp>]
+let Setup () =
+    ()
 
-    [<SetUp>]
-    member this.Setup () =
-        ()
-
-    [<Test>]
-    member this.Test1 () =
-        Assert.Pass()
+[<Test>]
+let Test1 () =
+    Assert.Pass()

--- a/Content/dotnet-new-nunit-fsharp/Company.TestProject1.fsproj
+++ b/Content/dotnet-new-nunit-fsharp/Company.TestProject1.fsproj
@@ -7,12 +7,13 @@
 
     <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
     <IsPackable Condition="'$(EnablePack)' != 'true'">false</IsPackable>
+    <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.11.0" />
+    <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Content/dotnet-new-nunit-fsharp/UnitTest1.fs
+++ b/Content/dotnet-new-nunit-fsharp/UnitTest1.fs
@@ -1,13 +1,11 @@
-namespace Company.TestProject1
+module Company.TestProject1
 
 open NUnit.Framework
 
-type TestClass () =
+[<SetUp>]
+let Setup () =
+    ()
 
-    [<SetUp>]
-    member this.Setup () =
-        ()
-
-    [<Test>]
-    member this.Test1 () =
-        Assert.Pass()
+[<Test>]
+let Test1 () =
+    Assert.Pass()

--- a/Content/dotnet-new-nunit-visualbasic/Company.TestProject1.vbproj
+++ b/Content/dotnet-new-nunit-visualbasic/Company.TestProject1.vbproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.11.0" />
+    <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
#27: Change to module, update deps, add GenerateProgramFile

Note, GenerateProgramFile fixes warning `A 'Program.fs' file can be automatically generated for F# .NET Core test projects. To fix this warning, either delete the file from the project, or set the <GenerateProgramFile> property to 'false'`, and is consistent with templates at https://github.com/dotnet/test-templates/tree/master/template_feed/Microsoft.DotNet.Test.ProjectTemplates.3.0/content/MSTest-FSharp.