### PR TITLE
Change case of framework NuGet package to match default

### DIFF
--- a/Content/dotnet-new-nunit-csharp/Company.TestProject1.csproj
+++ b/Content/dotnet-new-nunit-csharp/Company.TestProject1.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" Condition="'$(Framework)' &lt; 'netcoreapp2.0'"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" Condition="'$(Framework)' &gt;= 'netcoreapp2.0'"/>

--- a/Content/dotnet-new-nunit-fsharp/Company.TestProject1.fsproj
+++ b/Content/dotnet-new-nunit-fsharp/Company.TestProject1.fsproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" Condition="'$(Framework)' &lt; 'netcoreapp2.0'"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" Condition="'$(Framework)' &gt;= 'netcoreapp2.0'"/>

--- a/Content/dotnet-new-nunit-visualbasic/Company.TestProject1.vbproj
+++ b/Content/dotnet-new-nunit-visualbasic/Company.TestProject1.vbproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" Condition="'$(Framework)' &lt; 'netcoreapp2.0'"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" Condition="'$(Framework)' &gt;= 'netcoreapp2.0'"/>


### PR DESCRIPTION
Hey @halex2005,

This is just a tiny niggle, but I end up noticing it every time I use this tool. When you create an NUnit project by hand, the framework package is added as `NUnit`. When you create it with dotnet new, the package is added as `nunit`. This PR changes the casing to make the two consistent, whether they're created by hand, or by the tool.

Thanks for maintaining this tool -  I use it for every new project these days. 😄 