### PR TITLE
Add net5.0 support and remove out-of-support .NET Core versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,17 +16,16 @@ matrix:
       mono: none
 script:
   # installing .NET Core SDK and Mono
-  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then wget -q https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb; fi
+  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then wget -q https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb; fi
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then sudo dpkg -i packages-microsoft-prod.deb; fi
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then sudo apt-get update; fi
-  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then sudo apt-get install apt-transport-https dpkg; fi
-  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then sudo apt-get install dotnet-dev-1.1.8 dotnet-sdk-2.1 dotnet-sdk-2.2; fi
-  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then wget --retry-connrefused --waitretry=1 -O /tmp/dotnet-dev-osx-x64.1.1.8.pkg https://download.microsoft.com/download/6/5/F/65F1653E-F835-4DE3-BB36-F324D3925F32/dotnet-dev-osx-x64.1.1.8.pkg; fi
-  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then wget --retry-connrefused --waitretry=1 -O /tmp/dotnet-sdk-2.1.505-osx-x64.pkg https://download.visualstudio.microsoft.com/download/pr/7908138c-c0cf-4e5a-b28a-66cf7a781808/a36fe63192ee49593890d84b23729292/dotnet-sdk-2.1.505-osx-x64.pkg; fi
-  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then wget --retry-connrefused --waitretry=1 -O /tmp/dotnet-sdk-2.2.105-osx-x64.pkg https://download.visualstudio.microsoft.com/download/pr/4850aa8f-44a9-4c4a-9961-f18aa4d90ceb/07d790444f3ba6b412a76d6f1aced338/dotnet-sdk-2.2.105-osx-x64.pkg; fi
-  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then sudo installer -pkg /tmp/dotnet-dev-osx-x64.1.1.8.pkg -target /; fi
-  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then sudo installer -pkg /tmp/dotnet-sdk-2.1.505-osx-x64.pkg -target /; fi
-  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then sudo installer -pkg /tmp/dotnet-sdk-2.2.105-osx-x64.pkg -target /; fi
+  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then sudo apt-get install apt-transport-https; fi
+  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then sudo apt-get update; fi
+  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then sudo apt-get install dotnet-sdk-2.1 dotnet-sdk-3.1; fi
+  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then wget --retry-connrefused --waitretry=1 -O /tmp/dotnet-sdk-2.1.804-osx-x64.pkg https://download.visualstudio.microsoft.com/download/pr/f845905d-89d4-4e47-b2ec-398e47ff8411/2f49da28650e5259e694aa7321dcf935/dotnet-sdk-2.1.804-osx-x64.pkg; fi
+  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then wget --retry-connrefused --waitretry=1 -O /tmp/dotnet-sdk-3.1.102-osx-x64.pkg https://download.visualstudio.microsoft.com/download/pr/3533d626-4784-4944-9d3a-e62b9b46d11a/770e2b9c1a40546a19e063c39996fe7d/dotnet-sdk-3.1.102-osx-x64.pkg; fi
+  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then sudo installer -pkg /tmp/dotnet-sdk-2.1.804-osx-x64.pkg -target /; fi
+  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then sudo installer -pkg /tmp/dotnet-sdk-3.1.102-osx-x64.pkg -target /; fi
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then ln -s /usr/local/share/dotnet/dotnet /usr/local/bin/; fi
 
   # install dotnet new nunit template
@@ -34,18 +33,6 @@ script:
   - dotnet --info
 
   # creating projects from templates, run tests
-  - dotnet new nunit -n CSharpNetCore1   --framework netcoreapp1.0 -lang c#; dotnet test CSharpNetCore1;
-  - dotnet new nunit -n FSharpNetCore1   --framework netcoreapp1.0 -lang f#; dotnet test FSharpNetCore1;
-  - dotnet new nunit -n VBasicNetCore1   --framework netcoreapp1.0 -lang vb; dotnet test VBasicNetCore1;
-
-  - dotnet new nunit -n CSharpNetCore11  --framework netcoreapp1.1 -lang c#; dotnet test CSharpNetCore11;
-  - dotnet new nunit -n FSharpNetCore11  --framework netcoreapp1.1 -lang f#; dotnet test FSharpNetCore11;
-  - dotnet new nunit -n VBasicNetCore11  --framework netcoreapp1.1 -lang vb; dotnet test VBasicNetCore11;
-
-  - dotnet new nunit -n CSharpNetCore2   --framework netcoreapp2.0 -lang c#; dotnet test CSharpNetCore2;
-  - dotnet new nunit -n FSharpNetCore2   --framework netcoreapp2.0 -lang f#; dotnet test FSharpNetCore2;
-  - dotnet new nunit -n VBasicNetCore2   --framework netcoreapp2.0 -lang vb; dotnet test VBasicNetCore2;
-
   - dotnet new nunit -n CSharpNetCore21  --framework netcoreapp2.1 -lang c#;
   - dotnet new nunit-test -n NewTestFixture -o CSharpNetCore21 -lang c#;
   - dotnet test CSharpNetCore21;
@@ -55,10 +42,10 @@ script:
   - dotnet new nunit -n VBasicNetCore21  --framework netcoreapp2.1 -lang vb;
   - dotnet new nunit-test -n NewTestFixture -o VBasicNetCore21 -lang vb;
   - dotnet test VBasicNetCore21;
+  - dotnet new nunit -n CSharpNetCore31  --framework netcoreapp3.1 -lang c#; dotnet test CSharpNetCore31
+  - dotnet new nunit -n FSharpNetCore31  --framework netcoreapp3.1 -lang f#; dotnet test FSharpNetCore31
+  - dotnet new nunit -n VBasicNetCore31  --framework netcoreapp3.1 -lang vb; dotnet test VBasicNetCore31
 
-  - dotnet new nunit -n CSharpNetCore22   --framework netcoreapp2.2 -lang c#; dotnet test CSharpNetCore22
-  - dotnet new nunit -n FSharpNetCore22   --framework netcoreapp2.2 -lang f#; dotnet test FSharpNetCore22
-  - dotnet new nunit -n VBasicNetCore22   --framework netcoreapp2.2 -lang vb; dotnet test VBasicNetCore22
 
   # specify FrameworkPathOverride to run tests under Mono
   - export FrameworkPathOverride=/usr/lib/mono/4.7-api
@@ -102,21 +89,13 @@ script:
   #- if [[ $TRAVIS_OS_NAME == "linux" ]]; then dotnet new nunit -n CSharpNet48 --framework net48 -lang c#; dotnet test CSharpNet48; fi
   #- if [[ $TRAVIS_OS_NAME == "linux" ]]; then dotnet new nunit -n VBasicNet48 --framework net48 -lang vb; dotnet test VBasicNet48; fi
 
-  # install .net core sdk 3.0 + 3.1 preview
-  - if [[ $TRAVIS_OS_NAME == "linux" ]]; then sudo apt-get install dotnet-sdk-3.0; fi
-  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then wget --retry-connrefused --waitretry=1 -O /tmp/dotnet-sdk-3.0.100-osx-x64.pkg https://download.visualstudio.microsoft.com/download/pr/5c281f95-91c4-499d-baa2-31fec919047a/38c6964d72438ac30032bce516b655d9/dotnet-sdk-3.0.100-osx-x64.pkg; fi
-  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then sudo installer -pkg /tmp/dotnet-sdk-3.0.100-osx-x64.pkg -target /; fi
-
+  # install .net5.0-preview2 sdk
   - wget --retry-connrefused --waitretry=1 https://dot.net/v1/dotnet-install.sh
   - chmod +x dotnet-install.sh
-  - sudo ./dotnet-install.sh  --channel release/3.1.1xx
+  - sudo ./dotnet-install.sh  --channel release/5.0-preview2
   - sudo ~/.dotnet/dotnet new -i ./Content
   - sudo ~/.dotnet/dotnet --info
 
-  - dotnet new nunit -n CSharpNetCore30   --framework netcoreapp3.0 -lang c#; dotnet test CSharpNetCore30
-  - dotnet new nunit -n FSharpNetCore30   --framework netcoreapp3.0 -lang f#; dotnet test FSharpNetCore30
-  - dotnet new nunit -n VBasicNetCore30   --framework netcoreapp3.0 -lang vb; dotnet test VBasicNetCore30
-
-  - sudo ~/.dotnet/dotnet new nunit -n CSharpNetCore31   --framework netcoreapp3.1 -lang c#; sudo ~/.dotnet/dotnet test CSharpNetCore31
-  - sudo ~/.dotnet/dotnet new nunit -n FSharpNetCore31   --framework netcoreapp3.1 -lang f#; sudo ~/.dotnet/dotnet test FSharpNetCore31
-  - sudo ~/.dotnet/dotnet new nunit -n VBasicNetCore31   --framework netcoreapp3.1 -lang vb; sudo ~/.dotnet/dotnet test VBasicNetCore31
+  - sudo ~/.dotnet/dotnet new nunit -n CSharpNet50  --framework net5.0 -lang c#; sudo ~/.dotnet/dotnet test CSharpNet50
+  - sudo ~/.dotnet/dotnet new nunit -n FSharpNet50  --framework net5.0 -lang f#; sudo ~/.dotnet/dotnet test FSharpNet50
+  - sudo ~/.dotnet/dotnet new nunit -n VBasicNet50  --framework net5.0 -lang vb; sudo ~/.dotnet/dotnet test VBasicNet50

--- a/Content/dotnet-new-nunit-csharp/.template.config/dotnetcli.host.json
+++ b/Content/dotnet-new-nunit-csharp/.template.config/dotnetcli.host.json
@@ -20,6 +20,6 @@
   },
   "usageExamples": [
     "-f net472",
-    "-f netcoreapp2.1"
+    "-f net5.0"
   ]
 }

--- a/Content/dotnet-new-nunit-csharp/.template.config/template.json
+++ b/Content/dotnet-new-nunit-csharp/.template.config/template.json
@@ -29,32 +29,16 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp1.0",
-          "description": "Target netcoreapp1.0"
-        },
-        {
-          "choice": "netcoreapp1.1",
-          "description": "Target netcoreapp1.1"
-        },
-        {
-          "choice": "netcoreapp2.0",
-          "description": "Target netcoreapp2.0"
-        },
-        {
           "choice": "netcoreapp2.1",
           "description": "Target netcoreapp2.1"
         },
         {
-          "choice": "netcoreapp2.2",
-          "description": "Target netcoreapp2.2"
-        },
-        {
-          "choice": "netcoreapp3.0",
-          "description": "Target netcoreapp3.0"
-        },
-        {
           "choice": "netcoreapp3.1",
           "description": "Target netcoreapp3.1"
+        },
+        {
+          "choice": "net5.0",
+          "description": "Target net5.0"
         },
         {
           "choice": "net35",
@@ -105,8 +89,8 @@
           "description": "Target net48"
         }
       ],
-      "replaces": "netcoreapp2.1",
-      "defaultValue": "netcoreapp3.1"
+      "replaces": "net5.0",
+      "defaultValue": "net5.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/Content/dotnet-new-nunit-csharp/Company.TestProject1.csproj
+++ b/Content/dotnet-new-nunit-csharp/Company.TestProject1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp2.1</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net5.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
 
@@ -12,8 +12,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" Condition="'$(Framework)' &lt; 'netcoreapp2.0'"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" Condition="'$(Framework)' &gt;= 'netcoreapp2.0'"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
   </ItemGroup>
 
 </Project>

--- a/Content/dotnet-new-nunit-fsharp/.template.config/dotnetcli.host.json
+++ b/Content/dotnet-new-nunit-fsharp/.template.config/dotnetcli.host.json
@@ -20,6 +20,6 @@
   },
   "usageExamples": [
     "-f net472",
-    "-f netcoreapp2.1"
+    "-f net5.0"
   ]
 }

--- a/Content/dotnet-new-nunit-fsharp/.template.config/template.json
+++ b/Content/dotnet-new-nunit-fsharp/.template.config/template.json
@@ -29,32 +29,16 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp1.0",
-          "description": "Target netcoreapp1.0"
-        },
-        {
-          "choice": "netcoreapp1.1",
-          "description": "Target netcoreapp1.1"
-        },
-        {
-          "choice": "netcoreapp2.0",
-          "description": "Target netcoreapp2.0"
-        },
-        {
           "choice": "netcoreapp2.1",
           "description": "Target netcoreapp2.1"
         },
         {
-          "choice": "netcoreapp2.2",
-          "description": "Target netcoreapp2.2"
-        },
-        {
-          "choice": "netcoreapp3.0",
-          "description": "Target netcoreapp3.0"
-        },
-        {
           "choice": "netcoreapp3.1",
           "description": "Target netcoreapp3.1"
+        },
+        {
+          "choice": "net5.0",
+          "description": "Target net5.0"
         },
         {
           "choice": "net35",
@@ -105,8 +89,8 @@
           "description": "Target net48"
         }
       ],
-      "replaces": "netcoreapp2.1",
-      "defaultValue": "netcoreapp3.1"
+      "replaces": "net5.0",
+      "defaultValue": "net5.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/Content/dotnet-new-nunit-fsharp/Company.TestProject1.fsproj
+++ b/Content/dotnet-new-nunit-fsharp/Company.TestProject1.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp2.1</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net5.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
     <RootNamespace Condition="'$(name)' != '$(name{-VALUE-FORMS-}safe_namespace)'">Company.TestProject1</RootNamespace>
 
@@ -13,8 +13,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" Condition="'$(Framework)' &lt; 'netcoreapp2.0'"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" Condition="'$(Framework)' &gt;= 'netcoreapp2.0'"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Content/dotnet-new-nunit-visualbasic/.template.config/dotnetcli.host.json
+++ b/Content/dotnet-new-nunit-visualbasic/.template.config/dotnetcli.host.json
@@ -20,6 +20,6 @@
   },
   "usageExamples": [
     "-f net472",
-    "-f netcoreapp2.1"
+    "-f net5.0"
   ]
 }

--- a/Content/dotnet-new-nunit-visualbasic/.template.config/template.json
+++ b/Content/dotnet-new-nunit-visualbasic/.template.config/template.json
@@ -29,32 +29,16 @@
       "datatype": "choice",
       "choices": [
         {
-          "choice": "netcoreapp1.0",
-          "description": "Target netcoreapp1.0"
-        },
-        {
-          "choice": "netcoreapp1.1",
-          "description": "Target netcoreapp1.1"
-        },
-        {
-          "choice": "netcoreapp2.0",
-          "description": "Target netcoreapp2.0"
-        },
-        {
           "choice": "netcoreapp2.1",
           "description": "Target netcoreapp2.1"
         },
         {
-          "choice": "netcoreapp2.2",
-          "description": "Target netcoreapp2.2"
-        },
-        {
-          "choice": "netcoreapp3.0",
-          "description": "Target netcoreapp3.0"
-        },
-        {
           "choice": "netcoreapp3.1",
           "description": "Target netcoreapp3.1"
+        },
+        {
+          "choice": "net5.0",
+          "description": "Target net5.0"
         },
         {
           "choice": "net35",
@@ -105,8 +89,8 @@
           "description": "Target net48"
         }
       ],
-      "replaces": "netcoreapp2.1",
-      "defaultValue": "netcoreapp3.1"
+      "replaces": "net5.0",
+      "defaultValue": "net5.0"
     },
     "EnablePack": {
       "type": "parameter",

--- a/Content/dotnet-new-nunit-visualbasic/Company.TestProject1.vbproj
+++ b/Content/dotnet-new-nunit-visualbasic/Company.TestProject1.vbproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">netcoreapp2.1</TargetFramework>
+    <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net5.0</TargetFramework>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' != ''">TargetFrameworkOverride</TargetFramework>
 
     <IsPackable Condition="'$(EnablePack)' == 'true'">true</IsPackable>
@@ -11,8 +11,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" Condition="'$(Framework)' &lt; 'netcoreapp2.0'"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" Condition="'$(Framework)' &gt;= 'netcoreapp2.0'"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
   </ItemGroup>
 
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,4 @@
 image:
-  - Visual Studio 2017
   - Visual Studio 2019 Preview
 version: 1.0.{build}
 platform:
@@ -7,165 +6,113 @@ platform:
 configuration:
   - Release
 
-for:
--
-  matrix:
-    only:
-      - image: Visual Studio 2017
+build_script:
+  - nuget pack nunit-template.nuspec
+  - dotnet new -i ./Content
+  - dotnet --info
 
-  build_script:
-    - nuget pack nunit-template.nuspec
-    - dotnet new -i ./Content
-    - dotnet --info
+  - dotnet new nunit -n CSharpNetCore21  --framework netcoreapp2.1 -lang c#
+  - dotnet new nunit -n FSharpNetCore21  --framework netcoreapp2.1 -lang f#
+  - dotnet new nunit -n VBasicNetCore21  --framework netcoreapp2.1 -lang vb
 
-    - dotnet new nunit -n CSharpNetCore1   --framework netcoreapp1.0 -lang c#
-    - dotnet new nunit -n FSharpNetCore1   --framework netcoreapp1.0 -lang f#
-    - dotnet new nunit -n VBasicNetCore1   --framework netcoreapp1.0 -lang vb
+  - dotnet new nunit -n CSharpNetCore31  --framework netcoreapp3.1 -lang c#
+  - dotnet new nunit -n FSharpNetCore31  --framework netcoreapp3.1 -lang f#
+  - dotnet new nunit -n VBasicNetCore31  --framework netcoreapp3.1 -lang vb
 
-    - dotnet new nunit -n CSharpNetCore11  --framework netcoreapp1.1 -lang c#
-    - dotnet new nunit -n FSharpNetCore11  --framework netcoreapp1.1 -lang f#
-    - dotnet new nunit -n VBasicNetCore11  --framework netcoreapp1.1 -lang vb
+  - dotnet new nunit -n CSharpNet50  --framework net5.0 -lang c#
+  - dotnet new nunit -n FSharpNet50  --framework net5.0 -lang f#
+  - dotnet new nunit -n VBasicNet50  --framework net5.0 -lang vb
 
-  test_script:
-    - dotnet test CSharpNetCore1
-    - dotnet test FSharpNetCore1
-    - dotnet test VBasicNetCore1
+  - dotnet new nunit-test -n NewTestFixture -o CSharpNetCore21 -lang c#
+  - dotnet new nunit-test -n NewTestFixture -o FSharpNetCore21 -lang f#
+  - dotnet new nunit-test -n NewTestFixture -o VBasicNetCore21 -lang vb
 
-    - dotnet test CSharpNetCore11
-    - dotnet test FSharpNetCore11
-    - dotnet test VBasicNetCore11
+  # unfortunately, F# under full .NET Framework issues a compilation error, the issue is in F# compiler
+  - dotnet new nunit -n CSharpNet35  --framework net35 -lang c#
+  - dotnet new nunit -n VBasicNet35  --framework net35 -lang vb
 
-  artifacts:
-    - path: '*.nupkg'
+  - dotnet new nunit -n CSharpNet40  --framework net40 -lang c#
+  - dotnet new nunit -n VBasicNet40  --framework net40 -lang vb
 
--
-  matrix:
-    only:
-      - image: Visual Studio 2019 Preview
+  - dotnet new nunit -n CSharpNet45  --framework net45 -lang c#
+  - dotnet new nunit -n VBasicNet45  --framework net45 -lang vb
 
-  build_script:
-    - nuget pack nunit-template.nuspec
-    - dotnet new -i ./Content
-    - dotnet --info
+  - dotnet new nunit -n CSharpNet451 --framework net451 -lang c#
+  - dotnet new nunit -n VBasicNet451 --framework net451 -lang vb
 
-    - dotnet new nunit -n CSharpNetCore2   --framework netcoreapp2.0 -lang c#
-    - dotnet new nunit -n FSharpNetCore2   --framework netcoreapp2.0 -lang f#
-    - dotnet new nunit -n VBasicNetCore2   --framework netcoreapp2.0 -lang vb
+  - dotnet new nunit -n CSharpNet452 --framework net452 -lang c#
+  - dotnet new nunit -n VBasicNet452 --framework net452 -lang vb
 
-    - dotnet new nunit -n CSharpNetCore21  --framework netcoreapp2.1 -lang c#
-    - dotnet new nunit -n FSharpNetCore21  --framework netcoreapp2.1 -lang f#
-    - dotnet new nunit -n VBasicNetCore21  --framework netcoreapp2.1 -lang vb
+  - dotnet new nunit -n CSharpNet46  --framework net46 -lang c#
+  - dotnet new nunit -n VBasicNet46  --framework net46 -lang vb
 
-    - dotnet new nunit -n CSharpNetCore22  --framework netcoreapp2.2 -lang c#
-    - dotnet new nunit -n FSharpNetCore22  --framework netcoreapp2.2 -lang f#
-    - dotnet new nunit -n VBasicNetCore22  --framework netcoreapp2.2 -lang vb
+  - dotnet new nunit -n CSharpNet461 --framework net461 -lang c#
+  - dotnet new nunit -n VBasicNet461 --framework net461 -lang vb
 
-    - dotnet new nunit -n CSharpNetCore30  --framework netcoreapp3.0 -lang c#
-    - dotnet new nunit -n FSharpNetCore30  --framework netcoreapp3.0 -lang f#
-    - dotnet new nunit -n VBasicNetCore30  --framework netcoreapp3.0 -lang vb
+  - dotnet new nunit -n CSharpNet462 --framework net462 -lang c#
+  - dotnet new nunit -n VBasicNet462 --framework net462 -lang vb
 
-    - dotnet new nunit -n CSharpNetCore31  --framework netcoreapp3.1 -lang c#
-    - dotnet new nunit -n FSharpNetCore31  --framework netcoreapp3.1 -lang f#
-    - dotnet new nunit -n VBasicNetCore31  --framework netcoreapp3.1 -lang vb
+  - dotnet new nunit -n CSharpNet47 --framework net47 -lang c#
+  - dotnet new nunit -n VBasicNet47 --framework net47 -lang vb
 
-    - dotnet new nunit-test -n NewTestFixture -o CSharpNetCore21 -lang c#
-    - dotnet new nunit-test -n NewTestFixture -o FSharpNetCore21 -lang f#
-    - dotnet new nunit-test -n NewTestFixture -o VBasicNetCore21 -lang vb
+  - dotnet new nunit -n CSharpNet471 --framework net471 -lang c#
+  - dotnet new nunit -n VBasicNet471 --framework net471 -lang vb
 
-    # unfortunately, F# under full .NET Framework issues a compilation error, the issue is in F# compiler
-    - dotnet new nunit -n CSharpNet35  --framework net35 -lang c#
-    - dotnet new nunit -n VBasicNet35  --framework net35 -lang vb
+  - dotnet new nunit -n CSharpNet472 --framework net472 -lang c#
+  - dotnet new nunit -n VBasicNet472 --framework net472 -lang vb
 
-    - dotnet new nunit -n CSharpNet40  --framework net40 -lang c#
-    - dotnet new nunit -n VBasicNet40  --framework net40 -lang vb
+  - dotnet new nunit -n CSharpNet48 --framework net48 -lang c#
+  - dotnet new nunit -n VBasicNet48 --framework net48 -lang vb
 
-    - dotnet new nunit -n CSharpNet45  --framework net45 -lang c#
-    - dotnet new nunit -n VBasicNet45  --framework net45 -lang vb
+test_script:
+  - dotnet test CSharpNetCore21
+  - dotnet test FSharpNetCore21
+  - dotnet test VBasicNetCore21
 
-    - dotnet new nunit -n CSharpNet451 --framework net451 -lang c#
-    - dotnet new nunit -n VBasicNet451 --framework net451 -lang vb
+  - dotnet test CSharpNetCore31
+  - dotnet test FSharpNetCore31
+  - dotnet test VBasicNetCore31
 
-    - dotnet new nunit -n CSharpNet452 --framework net452 -lang c#
-    - dotnet new nunit -n VBasicNet452 --framework net452 -lang vb
+  - dotnet test CSharpNet50
+  - dotnet test FSharpNet50
+  - dotnet test VBasicNet50
 
-    - dotnet new nunit -n CSharpNet46  --framework net46 -lang c#
-    - dotnet new nunit -n VBasicNet46  --framework net46 -lang vb
+  - msbuild /p:FrameworkPathOverride="%programfiles(x86)%\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client" CSharpNet35
+  - msbuild /p:FrameworkPathOverride="%programfiles(x86)%\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client" VBasicNet35
+  - dotnet test CSharpNet35 --no-build
+  - dotnet test VBasicNet35 --no-build
 
-    - dotnet new nunit -n CSharpNet461 --framework net461 -lang c#
-    - dotnet new nunit -n VBasicNet461 --framework net461 -lang vb
+  - dotnet test CSharpNet40
+  - dotnet test VBasicNet40
 
-    - dotnet new nunit -n CSharpNet462 --framework net462 -lang c#
-    - dotnet new nunit -n VBasicNet462 --framework net462 -lang vb
+  - dotnet test CSharpNet45
+  - dotnet test VBasicNet45
 
-    - dotnet new nunit -n CSharpNet47 --framework net47 -lang c#
-    - dotnet new nunit -n VBasicNet47 --framework net47 -lang vb
+  - dotnet test CSharpNet451
+  - dotnet test VBasicNet451
 
-    - dotnet new nunit -n CSharpNet471 --framework net471 -lang c#
-    - dotnet new nunit -n VBasicNet471 --framework net471 -lang vb
+  - dotnet test CSharpNet452
+  - dotnet test VBasicNet452
 
-    - dotnet new nunit -n CSharpNet472 --framework net472 -lang c#
-    - dotnet new nunit -n VBasicNet472 --framework net472 -lang vb
+  - dotnet test CSharpNet46
+  - dotnet test VBasicNet46
 
-    - dotnet new nunit -n CSharpNet48 --framework net48 -lang c#
-    - dotnet new nunit -n VBasicNet48 --framework net48 -lang vb
+  - dotnet test CSharpNet461
+  - dotnet test VBasicNet461
 
-  test_script:
-    - dotnet test CSharpNetCore2
-    - dotnet test FSharpNetCore2
-    - dotnet test VBasicNetCore2
+  - dotnet test CSharpNet462
+  - dotnet test VBasicNet462
 
-    - dotnet test CSharpNetCore21
-    - dotnet test FSharpNetCore21
-    - dotnet test VBasicNetCore21
+  - dotnet test CSharpNet47
+  - dotnet test VBasicNet47
 
-    - dotnet test CSharpNetCore22
-    - dotnet test FSharpNetCore22
-    - dotnet test VBasicNetCore22
+  - dotnet test CSharpNet471
+  - dotnet test VBasicNet471
 
-    - dotnet test CSharpNetCore30
-    - dotnet test FSharpNetCore30
-    - dotnet test VBasicNetCore30
+  - dotnet test CSharpNet472
+  - dotnet test VBasicNet472
 
-    - dotnet test CSharpNetCore31
-    - dotnet test FSharpNetCore31
-    - dotnet test VBasicNetCore31
-
-    - msbuild /p:FrameworkPathOverride="%programfiles(x86)%\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client" CSharpNet35
-    - msbuild /p:FrameworkPathOverride="%programfiles(x86)%\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client" VBasicNet35
-    - dotnet test CSharpNet35 --no-build
-    - dotnet test VBasicNet35 --no-build
-
-    - dotnet test CSharpNet40
-    - dotnet test VBasicNet40
-
-    - dotnet test CSharpNet45
-    - dotnet test VBasicNet45
-
-    - dotnet test CSharpNet451
-    - dotnet test VBasicNet451
-
-    - dotnet test CSharpNet452
-    - dotnet test VBasicNet452
-
-    - dotnet test CSharpNet46
-    - dotnet test VBasicNet46
-
-    - dotnet test CSharpNet461
-    - dotnet test VBasicNet461
-
-    - dotnet test CSharpNet462
-    - dotnet test VBasicNet462
-
-    - dotnet test CSharpNet47
-    - dotnet test VBasicNet47
-
-    - dotnet test CSharpNet471
-    - dotnet test VBasicNet471
-
-    - dotnet test CSharpNet472
-    - dotnet test VBasicNet472
-
-    - dotnet test CSharpNet48
-    - dotnet test VBasicNet48
-  artifacts:
-    - path: '*.nupkg'
+  - dotnet test CSharpNet48
+  - dotnet test VBasicNet48
+artifacts:
+  - path: '*.nupkg'

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+14 March 2020, 1.8.0
+----------------------
+
+- update all project templates to default to .NET 5 (net5.0). Other frameworks can still be selected with the `--framework` command line option.
+- remove out of support .NET Core frameworks (1.0, 1.1, 2.0, 2.2, 3.0)
+
 12 November 2019, 1.6.5 and 1.7.1
 ---------------------------------
 

--- a/nunit-template.nuspec
+++ b/nunit-template.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>NUnit3.DotNetNew.Template</id>
     <title>NUnit 3 template for dotnet-new</title>
-    <version>1.7.1</version>
+    <version>1.8.0</version>
     <description>Project and item templates containing basic NUnit 3 Test Project.</description>
     <tags>NUnit dotnet core</tags>
     <authors>akharlov</authors>
@@ -20,7 +20,8 @@
 - NUnit3TestAdapter v3.15.1
 - Microsoft.NET.Test.Sdk v16.4.0
 - add new `--framework` supported parameters: .NET Core 3.1 version netcoreapp3.1
-- update all project templates to default to .NET Core 3.1 (netcoreapp3.1). Other frameworks can still be selected with the `--framework` command line option.
+- update all project templates to default to .NET 5 (net5.0). Other frameworks can still be selected with the `--framework` command line option.
+- remove out of support .NET Core frameworks (1.0, 1.1, 2.0, 2.2, 3.0)
     </releaseNotes>
   </metadata>
   <files>

--- a/readme.md
+++ b/readme.md
@@ -31,18 +31,18 @@ To create new NUnit library project from template, run:
 dotnet new nunit
 ```
 
-By default it will create NUnit Test Project targeted to `netcoreapp3.0`.
+By default it will create NUnit Test Project targeted to `net5.0`.
 You can specify `--framework` command line switch to change targeting:
 
 ```
-dotnet new nunit --framework netcoreapp1.1
+dotnet new nunit --framework netcoreapp3.1
 ```
 
 To specify new folder name for your NUnit Test Project you can use `-n` switch.
 Following command will create `NUnit-Tests` folder and will generate NUnit Test Project there:
 
 ```
-dotnet new nunit -n NUnit-Tests --framework netcoreapp1.0
+dotnet new nunit -n NUnit-Tests --framework netcoreapp3.1
 ```
 
 If you'd like to create F# or VB test project, you can specify project language with `-lang` switch:


### PR DESCRIPTION
Contributes towards https://github.com/dotnet/sdk/issues/10756

Adding net5.0 support (which lands in 5.0-preview2) and remove .NET Core
versions which aren't supported anymore: 1.0, 1.1, 2.0, 2.2, 3.0

cc @halex2005

This is blocked until .NET 5 Preview 2 is released (Travis) and a newer ` Visual Studio 2019 Preview` image with it is released (AppVeyor).