### PR TITLE
replace `netcoreapp5.0` to `net5.0` due to changes in .NET Core SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,15 +67,15 @@ jobs:
       dist: bionic
       mono: none
       script:
-        - curl -L https://aka.ms/install-dotnet-preview -o install-dotnet-preview.sh
+        - "curl -H 'Cache-Control: no-cache' -L https://aka.ms/install-dotnet-preview -o install-dotnet-preview.sh"
         - sudo bash install-dotnet-preview.sh
 
         - dotnet new -i ./Content
         - dotnet --info
 
-        - dotnet new nunit -n CSharpNetCore50   --framework netcoreapp5.0 -lang c#; dotnet test CSharpNetCore50
-        - dotnet new nunit -n FSharpNetCore50   --framework netcoreapp5.0 -lang f#; dotnet test FSharpNetCore50
-        - dotnet new nunit -n VBasicNetCore50   --framework netcoreapp5.0 -lang vb; dotnet test VBasicNetCore50
+        - dotnet new nunit -n CSharpNetCore50   --framework net5.0 -lang c#; dotnet test CSharpNetCore50
+        - dotnet new nunit -n FSharpNetCore50   --framework net5.0 -lang f#; dotnet test FSharpNetCore50
+        - dotnet new nunit -n VBasicNetCore50   --framework net5.0 -lang vb; dotnet test VBasicNetCore50
 
     - name: '[ubuntu bionic] Support for Mono'
       os: linux
@@ -198,13 +198,13 @@ jobs:
       osx_image: xcode11.2
       mono: none
       script:
-        - wget --retry-connrefused --waitretry=1 -O /tmp/dotnet-sdk-5.0.100-osx-x64.pkg https://download.visualstudio.microsoft.com/download/pr/f262d833-69d3-4aa1-bac1-b32075bebed3/474be39cca68cd46d3dc2cc03188f217/dotnet-sdk-5.0.100-preview.1.20155.7-osx-x64.pkg
+        - wget --retry-connrefused --waitretry=1 -O /tmp/dotnet-sdk-5.0.100-osx-x64.pkg https://download.visualstudio.microsoft.com/download/pr/3ce4af4f-f5d5-406c-a065-2ecc9bcc5fd2/353affd22a0727b476998312738ac35f/dotnet-sdk-5.0.100-preview.2.20176.6-osx-x64.pkg
         - sudo installer -pkg /tmp/dotnet-sdk-5.0.100-osx-x64.pkg -target /
         - ln -s /usr/local/share/dotnet/dotnet /usr/local/bin/
 
         - dotnet new -i ./Content
         - dotnet --info
 
-        - dotnet new nunit -n CSharpNetCore50   --framework netcoreapp5.0 -lang c#; dotnet test CSharpNetCore50
-        - dotnet new nunit -n FSharpNetCore50   --framework netcoreapp5.0 -lang f#; dotnet test FSharpNetCore50
-        - dotnet new nunit -n VBasicNetCore50   --framework netcoreapp5.0 -lang vb; dotnet test VBasicNetCore50
+        - dotnet new nunit -n CSharpNetCore50   --framework net5.0 -lang c#; dotnet test CSharpNetCore50
+        - dotnet new nunit -n FSharpNetCore50   --framework net5.0 -lang f#; dotnet test FSharpNetCore50
+        - dotnet new nunit -n VBasicNetCore50   --framework net5.0 -lang vb; dotnet test VBasicNetCore50

--- a/Content/dotnet-new-nunit-csharp/.template.config/dotnetcli.host.json
+++ b/Content/dotnet-new-nunit-csharp/.template.config/dotnetcli.host.json
@@ -21,6 +21,6 @@
   "usageExamples": [
     "-f net472",
     "-f netcoreapp2.1",
-    "-f netcoreapp5.0"
+    "-f net5.0"
   ]
 }

--- a/Content/dotnet-new-nunit-csharp/.template.config/template.json
+++ b/Content/dotnet-new-nunit-csharp/.template.config/template.json
@@ -57,8 +57,8 @@
           "description": "Target netcoreapp3.1"
         },
         {
-          "choice": "netcoreapp5.0",
-          "description": "Target netcoreapp5.0"
+          "choice": "net5.0",
+          "description": "Target net5.0"
         },
         {
           "choice": "net35",
@@ -110,7 +110,7 @@
         }
       ],
       "replaces": "netcoreapp2.1",
-      "defaultValue": "netcoreapp5.0"
+      "defaultValue": "net5.0"
     },
     "DotNetFramework": {
       "type": "computed",
@@ -131,6 +131,10 @@
     "DotNetCoreGreaterOrEqualThan21": {
       "type": "computed",
       "value": "(Framework >= \"netcoreapp2.1\" && Framework <= \"netcoreapp9\")"
+    },
+    "DotNetCoreGreaterOrEqualThan50": {
+      "type": "computed",
+      "value": "(Framework >= \"net5.0\" && Framework < \"net9.0\")"
     },
     "EnablePack": {
       "type": "parameter",

--- a/Content/dotnet-new-nunit-csharp/Company.TestProject1.csproj
+++ b/Content/dotnet-new-nunit-csharp/Company.TestProject1.csproj
@@ -13,9 +13,11 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" Condition="$(DotNetCoreLessThan21)" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" Condition="$(DotNetCoreGreaterOrEqualThan21)" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" Condition="$(DotNetCoreGreaterOrEqualThan50)" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" Condition="$(DotNetFramework)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" Condition="$(DotNetCoreLessThan20)"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" Condition="$(DotNetCoreGreaterOrEqualThan20)"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" Condition="$(DotNetCoreGreaterOrEqualThan50)"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" Condition="$(DotNetFramework)"/>
   </ItemGroup>
 

--- a/Content/dotnet-new-nunit-fsharp/.template.config/dotnetcli.host.json
+++ b/Content/dotnet-new-nunit-fsharp/.template.config/dotnetcli.host.json
@@ -21,6 +21,6 @@
   "usageExamples": [
     "-f net472",
     "-f netcoreapp2.1",
-    "-f netcoreapp5.0"
+    "-f net5.0"
   ]
 }

--- a/Content/dotnet-new-nunit-fsharp/.template.config/template.json
+++ b/Content/dotnet-new-nunit-fsharp/.template.config/template.json
@@ -57,8 +57,8 @@
           "description": "Target netcoreapp3.1"
         },
         {
-          "choice": "netcoreapp5.0",
-          "description": "Target netcoreapp5.0"
+          "choice": "net5.0",
+          "description": "Target net5.0"
         },
         {
           "choice": "net35",
@@ -110,7 +110,7 @@
         }
       ],
       "replaces": "netcoreapp2.1",
-      "defaultValue": "netcoreapp5.0"
+      "defaultValue": "net5.0"
     },
     "DotNetFramework": {
       "type": "computed",
@@ -131,6 +131,10 @@
     "DotNetCoreGreaterOrEqualThan21": {
       "type": "computed",
       "value": "(Framework >= \"netcoreapp2.1\" && Framework <= \"netcoreapp9\")"
+    },
+    "DotNetCoreGreaterOrEqualThan50": {
+      "type": "computed",
+      "value": "(Framework >= \"net5.0\" && Framework < \"net9.0\")"
     },
     "EnablePack": {
       "type": "parameter",

--- a/Content/dotnet-new-nunit-fsharp/Company.TestProject1.fsproj
+++ b/Content/dotnet-new-nunit-fsharp/Company.TestProject1.fsproj
@@ -14,9 +14,11 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" Condition="$(DotNetCoreLessThan21)" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" Condition="$(DotNetCoreGreaterOrEqualThan21)" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" Condition="$(DotNetCoreGreaterOrEqualThan50)" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" Condition="$(DotNetFramework)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" Condition="$(DotNetCoreLessThan20)"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" Condition="$(DotNetCoreGreaterOrEqualThan20)"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" Condition="$(DotNetCoreGreaterOrEqualThan50)"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" Condition="$(DotNetFramework)"/>
   </ItemGroup>
 

--- a/Content/dotnet-new-nunit-visualbasic/.template.config/dotnetcli.host.json
+++ b/Content/dotnet-new-nunit-visualbasic/.template.config/dotnetcli.host.json
@@ -21,6 +21,6 @@
   "usageExamples": [
     "-f net472",
     "-f netcoreapp2.1",
-    "-f netcoreapp5.0"
+    "-f net5.0"
   ]
 }

--- a/Content/dotnet-new-nunit-visualbasic/.template.config/template.json
+++ b/Content/dotnet-new-nunit-visualbasic/.template.config/template.json
@@ -57,8 +57,8 @@
           "description": "Target netcoreapp3.1"
         },
         {
-          "choice": "netcoreapp5.0",
-          "description": "Target netcoreapp5.0"
+          "choice": "net5.0",
+          "description": "Target net5.0"
         },
         {
           "choice": "net35",
@@ -110,7 +110,7 @@
         }
       ],
       "replaces": "netcoreapp2.1",
-      "defaultValue": "netcoreapp5.0"
+      "defaultValue": "net5.0"
     },
     "DotNetFramework": {
       "type": "computed",
@@ -131,6 +131,10 @@
     "DotNetCoreGreaterOrEqualThan21": {
       "type": "computed",
       "value": "(Framework >= \"netcoreapp2.1\" && Framework <= \"netcoreapp9\")"
+    },
+    "DotNetCoreGreaterOrEqualThan50": {
+      "type": "computed",
+      "value": "(Framework >= \"net5.0\" && Framework < \"net9.0\")"
     },
     "EnablePack": {
       "type": "parameter",

--- a/Content/dotnet-new-nunit-visualbasic/Company.TestProject1.vbproj
+++ b/Content/dotnet-new-nunit-visualbasic/Company.TestProject1.vbproj
@@ -12,9 +12,11 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" Condition="$(DotNetCoreLessThan21)" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" Condition="$(DotNetCoreGreaterOrEqualThan21)" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" Condition="$(DotNetCoreGreaterOrEqualThan50)" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" Condition="$(DotNetFramework)" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" Condition="$(DotNetCoreLessThan20)"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" Condition="$(DotNetCoreGreaterOrEqualThan20)"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" Condition="$(DotNetCoreGreaterOrEqualThan50)"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" Condition="$(DotNetFramework)"/>
   </ItemGroup>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -180,14 +180,14 @@ for:
     - nuget pack nunit-template.nuspec
 
     - appveyor DownloadFile https://dot.net/v1/dotnet-install.ps1
-    - powershell -NoProfile -NoLogo -ExecutionPolicy Unrestricted -Command ".\dotnet-install.ps1 --Version 5.0.100-preview.1.20155.7"
+    - powershell -NoProfile -NoLogo -ExecutionPolicy Unrestricted -Command ".\dotnet-install.ps1 --Version 5.0.100-preview.2.20176.6"
 
     - '"%USERPROFILE%\\AppData\\Local\\Microsoft\\dotnet\\dotnet" new -i ./Content'
     - '"%USERPROFILE%\\AppData\\Local\\Microsoft\\dotnet\\dotnet" --info'
 
-    - '"%USERPROFILE%\\AppData\\Local\\Microsoft\\dotnet\\dotnet" new nunit -n CSharpNetCore50 --framework netcoreapp5.0 -lang c#'
-    - '"%USERPROFILE%\\AppData\\Local\\Microsoft\\dotnet\\dotnet" new nunit -n FSharpNetCore50 --framework netcoreapp5.0 -lang f#'
-    - '"%USERPROFILE%\\AppData\\Local\\Microsoft\\dotnet\\dotnet" new nunit -n VBasicNetCore50 --framework netcoreapp5.0 -lang vb'
+    - '"%USERPROFILE%\\AppData\\Local\\Microsoft\\dotnet\\dotnet" new nunit -n CSharpNetCore50 --framework net5.0 -lang c#'
+    - '"%USERPROFILE%\\AppData\\Local\\Microsoft\\dotnet\\dotnet" new nunit -n FSharpNetCore50 --framework net5.0 -lang f#'
+    - '"%USERPROFILE%\\AppData\\Local\\Microsoft\\dotnet\\dotnet" new nunit -n VBasicNetCore50 --framework net5.0 -lang vb'
 
   test_script:
     - '"%USERPROFILE%\\AppData\\Local\\Microsoft\\dotnet\\dotnet" test CSharpNetCore50'

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+15 April 2020, v1.8.1
+---------------------
+
+- replace `netcoreapp5.0` to `net5.0` due to changes in 5.0.100-preview.2.20176.6 version of .NET Core SDK
+  (https://github.com/nunit/dotnet-new-nunit/issues/38)
+
 26 March 2020, v1.8.0
 ---------------------
 

--- a/nunit-template.nuspec
+++ b/nunit-template.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>NUnit3.DotNetNew.Template</id>
     <title>NUnit 3 template for dotnet-new</title>
-    <version>1.8.0</version>
+    <version>1.8.1</version>
     <description>Project and item templates containing basic NUnit 3 Test Project.</description>
     <tags>NUnit dotnet</tags>
     <authors>akharlov</authors>
@@ -19,8 +19,8 @@
 - NUnit v3.12.0
 - NUnit3TestAdapter v3.16.1
 - Microsoft.NET.Test.Sdk v16.5.0
-- add new `--framework` supported parameters: netcoreapp5.0
-- update all project templates to default to netcoreapp5.0. Other frameworks can still be selected with the `--framework` command line option.
+- add new `--framework` supported parameters: net5.0
+- update all project templates to default to net5.0. Other frameworks can still be selected with the `--framework` command line option.
     </releaseNotes>
   </metadata>
   <files>


### PR DESCRIPTION
.NET Core SDK v5.0.100-preview.2.20176.6 has changed TFM to `net5.0` #38 