### PR TITLE
removing duplicate defaultName properties

### DIFF
--- a/Content/dotnet-new-nunit-csharp/.template.config/template.json
+++ b/Content/dotnet-new-nunit-csharp/.template.config/template.json
@@ -160,7 +160,6 @@
       "path": "UnitTest1.cs"
     }
   ],
-  "defaultName": "TestProject1",
   "postActions": [
     {
       "condition": "(!skipRestore)",

--- a/Content/dotnet-new-nunit-fsharp/.template.config/template.json
+++ b/Content/dotnet-new-nunit-fsharp/.template.config/template.json
@@ -160,7 +160,6 @@
       "path": "UnitTest1.fs"
     }
   ],
-  "defaultName": "TestProject1",
   "postActions": [
     {
       "condition": "(!skipRestore)",

--- a/Content/dotnet-new-nunit-visualbasic/.template.config/template.json
+++ b/Content/dotnet-new-nunit-visualbasic/.template.config/template.json
@@ -160,7 +160,6 @@
       "path": "UnitTest1.vb"
     }
   ],
-  "defaultName": "TestProject1",
   "postActions": [
     {
       "condition": "(!skipRestore)",


### PR DESCRIPTION
I noticed that you had a few `template.json` files that have duplicate `defaultName` entries. As far as I know it is not causing any issues with the `dotnet new` cli or Visual Studio, but it's best to remove these duplicates.